### PR TITLE
Adding basic information on CRC.crc functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,7 @@ Status](https://travis-ci.org/TattdCodeMonkey/crc.png?branch=master)](https://tr
 [![Hex version](https://img.shields.io/hexpm/v/crc.svg "Hex
 version")](https://hex.pm/packages/crc)
 
-This module is used to calculate CRC (Cyclic Redundancy Check) values for binary data. It uses NIF functions written in C to interate over the given binary calculating the CRC checksum value.
-
-CRC implementations have been tested against these online calculators to validate their correctness to the best of our ability.
-
--  https://www.lammertbies.nl/comm/info/crc-calculation.html
--  http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
+This module is used to calculate CRC (Cyclic Redundancy Check) values for binary data. It uses NIF functions written in C to iterate over the given binary calculating the CRC checksum value. The NIFs are written to report their time slice usage and will not interfere with the schedulers.
 
 ## Installation
 
@@ -22,7 +17,63 @@ CRC implementations have been tested against these online calculators to validat
   end
 ```
 
-## Supported algorithms
+## Supported algorithms (models)
 
-- See [crc_model_<type>.c.h](/c_src/nif) files
+- Run `CRC.list/0` to get a full list of all pre-defined models
 
+## Usage
+
+To calculate a CRC-16 X-Modem checksum for the binary `<<1,2,3,4,5,4,3,2,1>>` using the pre-defined model:
+
+```elixir
+iex> CRC.crc(:crc_16_xmodem, <<1,2,3,4,5,4,3,2,1>>)
+31763
+```
+
+You can also create model's at runtime and re-use them. This can be done with a map:
+
+```elixir
+iex> model = CRC.crc_init(
+  %{
+    width: 16,
+    poly: 0x1021,
+    init: 0x00,
+    refin: false,
+    refout: false,
+    xorout: 0x00
+  }
+)
+#Reference<x.x.x.x>
+iex> CRC.crc(model, <<1,2,3,4,5,4,3,2,1>>)
+31763
+```
+
+Or extend pre-defined models:
+
+```elixir
+iex> model = CRC.crc_init(
+  %{
+    extend: :crc_16_xmodem,
+    init: 0x00,
+  }
+)
+#Reference<x.x.x.x>
+iex> CRC.crc(model, <<1,2,3,4,5,4,3,2,1>>)
+31763
+```
+
+## Tests
+
+CRC implementations have been tested against these online calculators to validate their correctness to the best of our ability.
+
+-  https://www.lammertbies.nl/comm/info/crc-calculation.html
+-  http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
+
+There are also two property tests that can use [PyCRC](https://github.com/tpircher/pycrc) or [CRC RevEng](https://sourceforge.net/projects/reveng/) if installed and configured locally.
+```bash
+$ export PYCRC_BIN=~/pycrc-0.9.1/pycrc.py
+$ export REVENG_BIN=~/reveng-1.5.2/reveng
+$ mix test
+```
+
+PyCRC is used as a part of the TravisCI test suite.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This module is used to calculate CRC (Cyclic Redundancy Check) values for binary
 
 ## Supported algorithms (models)
 
-- Run `CRC.list/0` to get a full list of all pre-defined models
+Run `CRC.list/0` to get a full list of all pre-defined models or `CRC.list/1` with a filter to search for a pre-defined model.
 
 ## Usage
 

--- a/lib/crc.ex
+++ b/lib/crc.ex
@@ -24,6 +24,14 @@ defmodule CRC do
   defdelegate crc_final(resource), to: :crc
 
   @doc """
+  Returns a list of all the pre-defined CRC models
+  """
+  def list() do
+    :crc_nif.crc_list()
+    |> Map.to_list()
+  end
+
+  @doc """
   Calculates a 8-bit CRC with polynomial x^8+x^6+x^3+x^2+1, 0x14D.
   Chosen based on Koopman, et al. (0xA6 in his notation = 0x14D >> 1):
   http://www.ece.cmu.edu/~koopman/roses/dsn04/koopman04_crc_poly_embedded.pdf

--- a/lib/crc.ex
+++ b/lib/crc.ex
@@ -23,12 +23,32 @@ defmodule CRC do
   @spec crc_final(:crc_algorithm.resource()) :: :crc_algorithm.value()
   defdelegate crc_final(resource), to: :crc
 
+  @model_list :crc_nif.crc_list() |> Map.to_list() |> Enum.map(fn {model, map} -> {model, Map.get(map, model)} end)
   @doc """
   Returns a list of all the pre-defined CRC models
   """
+  @spec list() :: [{atom, String.t}]
   def list() do
-    :crc_nif.crc_list()
-    |> Map.to_list()
+    @model_list
+  end
+
+  @doc """
+  Returns a list of all pre-defined CRC Models that match the filter given.
+
+  Filter is compiled into a regular expression and matched against the model name
+  and description.
+  """
+  @spec list(binary) :: [{atom, String.t}]
+  def list(filter) do
+    @model_list
+    |> Enum.filter(&(list_filter(&1, filter)))
+  end
+
+  defp list_filter({model_atom, model_name}, filter) do
+    atom_string = Atom.to_string(model_atom)
+
+    {:ok, rfilter} = Regex.compile(filter)
+    Regex.match?(rfilter, atom_string) or Regex.match?(rfilter, model_name)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule CRC.Mixfile do use Mix.Project
   def project() do
     [
       app: :crc,
-      version: "0.8.0",
+      version: "0.8.1",
       elixir: ">= 1.4.2 and < 2.0.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
@@ -27,7 +27,6 @@ defmodule CRC.Mixfile do use Mix.Project
 
   defp deps() do
     [
-      {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
       {:elixir_make, "~> 0.4", runtime: false},
       {:ex_doc, "~> 0.18", only: :dev},
       {:propcheck, "~> 1.0", only: :test}


### PR DESCRIPTION
Updated the README to have information on the pre-defined models for
`CRC.crc/2` as well creating or extending models at runtime.