### PR TITLE
Restore Windows build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,12 @@ erl_crash.dump
 /.idea
 /c_src/env.mk
 /c_src/Makefile.auto.win
+/c_src/*.obj
 /ebin
 /logs
 /priv/*.dll
+/priv/*.lib
+/priv/*.exp
 /priv/*.dylib
 /priv/*.so
 /crc.d

--- a/c_src/Makefile.win
+++ b/c_src/Makefile.win
@@ -18,7 +18,10 @@ NIF_SRC=\
   nif\crc_16_modbus.c\
   nif\crc_16_sick.c\
   nif\crc_32.c\
-  nif\crc_nif.c
+  nif\crc_nif.c\
+  nif\crc_algorithm.c\
+  nif\crc_model.c\
+  nif\crc_resource.c
 
 all: app
 
@@ -28,7 +31,7 @@ Makefile.auto.win:
 
 !IFDEF ERTS_INCLUDE_PATH
 app:
-  $(CC) $(CFLAGS) /I"$(ERTS_INCLUDE_PATH)" /LD /MD /F"..\priv\crc_nif.dll" $(NIF_SRC)
+  $(CC) $(CFLAGS) /I"$(ERTS_INCLUDE_PATH)" /LD /MD /Fe"..\priv\crc_nif.dll" $(NIF_SRC)
 !ELSE
 app: Makefile.auto.win
 	$(NMAKE) /F Makefile.win app

--- a/c_src/nif/crc_nif.h
+++ b/c_src/nif/crc_nif.h
@@ -10,9 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 #include <erl_nif.h>
 

--- a/c_src/nif/xnif_slice.h
+++ b/c_src/nif/xnif_slice.h
@@ -9,9 +9,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 #include <erl_nif.h>
 

--- a/c_src/nif/xnif_trace.h
+++ b/c_src/nif/xnif_trace.h
@@ -9,9 +9,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 #include <erl_nif.h>
 


### PR DESCRIPTION
Windows builds are broken since db972a12 (using Visual Studio Build Tools 2017 v15.2.2). This commit restores Windows support for 0.8.0.