### PR TITLE
Remove compile-time invocation of NIF

### DIFF
--- a/lib/crc.ex
+++ b/lib/crc.ex
@@ -23,13 +23,14 @@ defmodule CRC do
   @spec crc_final(:crc_algorithm.resource()) :: :crc_algorithm.value()
   defdelegate crc_final(resource), to: :crc
 
-  @model_list :crc_nif.crc_list() |> Map.to_list() |> Enum.map(fn {model, map} -> {model, Map.get(map, model)} end)
   @doc """
   Returns a list of all the pre-defined CRC models
   """
   @spec list() :: [{atom, String.t}]
   def list() do
-    @model_list
+    :crc_nif.crc_list()
+    |> Map.to_list()
+    |> Enum.map(fn {model, map} -> {model, Map.get(map, model)} end)
   end
 
   @doc """
@@ -40,7 +41,7 @@ defmodule CRC do
   """
   @spec list(binary) :: [{atom, String.t}]
   def list(filter) do
-    @model_list
+    list()
     |> Enum.filter(&(list_filter(&1, filter)))
   end
 


### PR DESCRIPTION
This makes it possible to crosscompile the library with Nerves.
Previously, :crc_nif.crc_list/0 would be called to cache the built-in
models. Now the NIF is called each time to get the list modules, but
that should be ok since this should not be a frequent operation.