### PR TITLE
v0.9.0 - Adding `CRC.calculate/2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,27 @@ This module is used to calculate CRC (Cyclic Redundancy Check) values for binary
 
 ## Installation
 
+### Elixir
   1. Add crc to your list of dependencies in `mix.exs`:
 
 ```elixir
   def deps do
-    [{:crc, "~> 0.8"}]
+    [{:crc, "~> 0.9.0"}]
   end
+```
+
+### Erlang
+  1. add crc to your `rebar.config`
+```erlang
+{deps, [
+  {crc, "0.9.0"}
+]}.
+```
+  
+  or `erlang.mk`
+
+```
+dep_crc = hex 0.9.0
 ```
 
 ## Supported algorithms (models)
@@ -28,11 +43,13 @@ To calculate a CRC-16 X-Modem checksum for the binary `<<1,2,3,4,5,4,3,2,1>>` us
 ```elixir
 iex> CRC.crc(:crc_16_xmodem, <<1,2,3,4,5,4,3,2,1>>)
 31763
+iex> CRC.calculate(<<1,2,3,4,5,4,3,2,1>>, :crc_16_xmodem)
+31763
 ```
 
 Or you can create a model at runtime, this can be done with a map:
 ```elixir
-iex> model = CRC.crc(
+iex> CRC.crc(
   %{
     width: 16,
     poly: 0x1021,
@@ -44,25 +61,8 @@ iex> model = CRC.crc(
   <<1,2,3,4,5,4,3,2,1>>
 )
 31763
-```
-
-Or you can extend one of the pre-defined models:
-
-```elixir
-iex> model = CRC.crc(
-  %{
-    extend: :crc_16_xmodem,
-    init: 0x00,
-  }, 
-  <<1,2,3,4,5,4,3,2,1>>
-)
-31763
-```
-
-You can also create a resource for a model at runtime and re-use it:
-
-```elixir
-iex> model = CRC.crc_init(
+iex> CRC.calculate(   
+  <<1,2,3,4,5,4,3,2,1>>,
   %{
     width: 16,
     poly: 0x1021,
@@ -72,12 +72,23 @@ iex> model = CRC.crc_init(
     xorout: 0x00
   }
 )
-#Reference<x.x.x.x>
-iex> CRC.crc(model, <<1,2,3,4,5,4,3,2,1>>)
 31763
 ```
 
-Resources can also be used to do partial updates to a calculation, and then finalized later:
+Or you can extend one of the pre-defined models:
+
+```elixir
+iex> CRC.crc(
+  %{
+    extend: :crc_16_xmodem,
+    init: 0x00,
+  }, 
+  <<1,2,3,4,5,4,3,2,1>>
+)
+31763
+```
+
+`CRC.crc_init/1` is used to create a resource and be used to do partial updates to a calculation that is then finalized later:
 
 ```elixir
 iex> resource = CRC.crc_init(:crc_16_xmodem)
@@ -89,6 +100,8 @@ iex> resource3 = CRC.crc_update(resource2, <<4, 3, 2, 1>>)
 iex>CRC.crc_final(resource3)
 31763
 ```
+
+This could be usefule to calculate a CRC for a larger binary that you are receiving asyncronously. 
 
 ## Tests
 

--- a/lib/crc.ex
+++ b/lib/crc.ex
@@ -12,7 +12,7 @@ defmodule CRC do
   """
 
   @doc """
-  Calculated a CRC checksum for the `input` based on the crc `params` given.
+  Calculate a CRC checksum for the `input` based on the crc `params` given.
 
   `params` can be an atom for one of the compiled models. See `CRC.list/0` for a full list.
   Or a Map with paramters to create a model at runtime. The map given should have all of the following keys:
@@ -76,6 +76,23 @@ defmodule CRC do
   """
   @spec crc_final(:crc_algorithm.resource()) :: :crc_algorithm.value()
   defdelegate crc_final(resource), to: :crc
+
+  @doc """
+  Calculate a CRC checksum for the `input` based on the crc `params` given.
+
+  See `CRC.crc/2` for details on valid `params`.
+
+  This function has the parameter order reversed to allow easier use with pipelines.
+  allowing code to be written like:
+  
+  ```elixir
+  read_data() |> CRC.calculate(:crc_16) |> do_something()
+  ```
+  """
+  @spec calculate(iodata(), :crc_algorithm.params()) :: :crc_algorithm.value()
+  def calculate(input, params) do
+    :crc.crc(params, input)
+  end
 
   @doc """
   Returns a list of all the compiled CRC models

--- a/lib/crc/legacy.ex
+++ b/lib/crc/legacy.ex
@@ -1,4 +1,6 @@
 defmodule CRC.Legacy do
+    @moduledoc false
+
     # Legacy CRC functions, these may be depraced in a future release and removed in v1.0 - RN
     defmacro __using__(_) do
         quote do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule CRC.Mixfile do use Mix.Project
   def project() do
     [
       app: :crc,
-      version: "0.8.3",
+      version: "0.9.0",
       elixir: ">= 1.4.2 and < 2.0.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/src/crc.app.src
+++ b/src/crc.app.src
@@ -2,7 +2,7 @@
 %% vim: ts=4 sw=4 ft=erlang noet
 {application, crc, [
   {description, "A library used to calculate CRC checksums for binary data"},
-  {vsn, "0.8.3"},
+  {vsn, "0.9.0"},
   {id, "git"},
   {registered, []},
   {applications, [

--- a/test/crc_test.exs
+++ b/test/crc_test.exs
@@ -28,6 +28,12 @@ defmodule CRCTest do
     assert CRC.checksum_xor(large_input) == ChecksumXOR.calc(large_input)
   end
 
+  test "calculate" do
+    assert CRC.calculate(@test_data_01, :crc_16) == 0xBB3D
+    large_input = :binary.copy(@test_data_01, 1024 * 40 + 1)
+    assert CRC.calculate(large_input, :crc_16) == 0xF8F6
+  end
+
   property "CRC-8/KOOP" do
     forall input in binary() do
       CRC.crc_8(input) == CRC8KOOP.calc(input)


### PR DESCRIPTION
Adding the `calculate/2` function to compliment the current `crc/2`
function but with the parameters reversed. This will allow piping binary
input from another function and passing parameters as the second
argument instead of the first.

Added `@moduledoc false` to legacy module so it doesn't appear in docs.

Update readme and app files for release of `v0.9`