### PR TITLE
Fixes gcc warning implicit declaration of strnlen

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -74,7 +74,7 @@ else ifeq ($(PLATFORM),freebsd)
 	CXXFLAGS ?= -O3 -std=c++11 -finline-functions -fstack-protector -Wall
 else ifeq ($(PLATFORM),linux)
 	CC ?= gcc
-	CFLAGS ?= -O3 -std=c11 -finline-functions -fstack-protector -Wall -Wmissing-prototypes
+	CFLAGS ?= -O3 -std=c11 -finline-functions -fstack-protector -Wall -Wmissing-prototypes -D_POSIX_C_SOURCE=200809L
 	CXXFLAGS ?= -O3 -std=c++11 -finline-functions -fstack-protector -Wall
 else ifeq ($(PLATFORM),solaris)
 	CC ?= cc


### PR DESCRIPTION
Because we are compiling with C11, we must also add the define
about _POSIX_C_SOURCE to avoid the warning about strnlen.