### PR TITLE
Support compiling in _build

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -3,13 +3,21 @@
 CURDIR := $(shell pwd)
 BASEDIR := $(abspath $(CURDIR)/..)
 
+ifneq ($(MIX_APP_PATH),)
+PREFIX = $(MIX_APP_PATH)/priv
+BUILD  = $(MIX_APP_PATH)/obj
+else
+PREFIX = $(BASEDIR)/priv
+BUILD  = $(CURDIR)/obj
+endif
+
 PROJECT = crc
 
 # Configuration.
 
 C_SRC_DIR ?= $(CURDIR)
 C_SRC_ENV ?= $(C_SRC_DIR)/env.mk
-C_SRC_NIF ?= $(BASEDIR)/priv/$(PROJECT)_nif
+C_SRC_NIF ?= $(PREFIX)/$(PROJECT)_nif
 
 # "erl" command.
 
@@ -135,7 +143,8 @@ endif
 ifeq ($(NIF_SOURCES),)
 NIF_SOURCES := $(sort $(foreach pat,*.c *.C *.cc *.cpp,$(call core_find,$(C_SRC_DIR)/nif/,$(pat))))
 endif
-NIF_OBJECTS = $(addsuffix .o, $(basename $(NIF_SOURCES)))
+NIF_OBJECTS_BASE = $(addsuffix .o, $(basename $(NIF_SOURCES)))
+NIF_OBJECTS = $(NIF_OBJECTS_BASE:$(C_SRC_DIR)/nif/%=$(BUILD)/%)
 
 COMPILE_C = $(c_verbose) $(CC) $(CFLAGS) $(CPPFLAGS) -c
 COMPILE_CPP = $(cpp_verbose) $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c
@@ -146,23 +155,25 @@ app:: $(C_SRC_ENV) $(C_SRC_NIF_FILE)
 
 test-build:: $(C_SRC_ENV) $(C_SRC_NIF_FILE)
 
-$(C_SRC_NIF_FILE): $(NIF_OBJECTS)
-	$(verbose) mkdir -p $(BASEDIR)/priv
+$(C_SRC_NIF_FILE): $(PREFIX) $(BUILD) $(NIF_OBJECTS)
 	$(link_verbose) $(CC) $(NIF_OBJECTS) \
 		$(LDFLAGS) -shared $(LDLIBS) \
 		-o $(C_SRC_NIF_FILE)
 
-%.o: %.c
+$(BUILD)/%.o: $(C_SRC_DIR)/nif/%.c
 	$(COMPILE_C) $(OUTPUT_OPTION) $<
 
-%.o: %.cc
+$(BUILD)/%.o: $(C_SRC_DIR)/nif/%.cc
 	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
 
-%.o: %.C
+$(BUILD)/%.o: $(C_SRC_DIR)/nif/%.C
 	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
 
-%.o: %.cpp
+$(BUILD)/%.o: $(C_SRC_DIR)/nif/%.cpp
 	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+$(PREFIX) $(BUILD):
+	$(verbose) mkdir -p $@
 
 clean:: clean-c_src
 


### PR DESCRIPTION
Found this on [twitter](https://twitter.com/TattdCodeMonkey/status/1222616396795957248?s=20). I happen to be doing quite a bit of this lately, so here you go 🎉

Fixes #31

Allows compiling in the _build directory of Elixir projects when available. This is especially helpful when dealing with multiple Nerves targets

As a note, this will only really affect those compiling for Elixir and using `elixir_make ~> 0.6` (If you want to enforce this, I can change `mix.exs` to reflect the elixir_make requirement).

Compiling with rebar/erlang should be unaffected. I'm also unfamiliar with compiling in windows, so that's untouched as well. But this is at least a start for a good majority 😉 