### PR TITLE
Fix OTP 23 build by removing erl_interface refs

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -100,10 +100,8 @@ ifneq ($(CROSSCOMPILER),)
 	CC = $(CROSSCOMPILER)gcc
 endif
 
-CFLAGS += -I"$(ERTS_INCLUDE_DIR)" -I"$(ERL_INTERFACE_INCLUDE_DIR)"
-CXXFLAGS += -I"$(ERTS_INCLUDE_DIR)" -I"$(ERL_INTERFACE_INCLUDE_DIR)"
-
-LDLIBS += -L"$(ERL_INTERFACE_LIB_DIR)" -lerl_interface -lei
+CFLAGS += -I"$(ERTS_INCLUDE_DIR)"
+CXXFLAGS += -I"$(ERTS_INCLUDE_DIR)"
 
 # Verbosity.
 
@@ -183,12 +181,8 @@ clean-c_src:
 $(C_SRC_ENV):
 	$(verbose) $(ERL) -eval "file:write_file(\"$(call core_native_path,$(C_SRC_ENV))\", \
 		io_lib:format( \
-			\"ERTS_INCLUDE_DIR ?= ~s/erts-~s/include/~n\" \
-			\"ERL_INTERFACE_INCLUDE_DIR ?= ~s~n\" \
-			\"ERL_INTERFACE_LIB_DIR ?= ~s~n\", \
-			[code:root_dir(), erlang:system_info(version), \
-			code:lib_dir(erl_interface, include), \
-			code:lib_dir(erl_interface, lib)])), \
+			\"ERTS_INCLUDE_DIR ?= ~s/erts-~s/include/~n\", \
+			[code:root_dir(), erlang:system_info(version)])), \
 		halt()."
 
 distclean:: distclean-env


### PR DESCRIPTION
OTP 23 removed the `erl_interface` library so linker references to it
produce errors now. Luckily `erl_interface` isn't being used, so
deleting it fixes the problem.

This also deletes the reference to the `ei` library since it isn't being
used either. `ei` still exists, though.

Tested on OTP 22 and 23 on OSX and Linux.