### PR TITLE
Fix elixir compiler warnings

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -12,13 +12,20 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
 
+    strategy:
+      # Specify the OTP and Elixir versions to use when building
+      # and running the workflow steps.
+      matrix:
+        otp: ['25.0.4', '26.0.1']       # Define the OTP version [required]
+        elixir: ['1.14.5', '1.15.0']    # Define the elixir version [required]
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Elixir
-      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+      uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.12.3' # Define the elixir version [required]
-        otp-version: '24.1' # Define the OTP version [required]
+        otp-version: ${{matrix.otp}}
+        elixir-version: ${{matrix.elixir}}
     - name: Restore dependencies cache
       uses: actions/cache@v2
       with:

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/crc/model.ex
+++ b/lib/crc/model.ex
@@ -11,10 +11,10 @@ defmodule CRC.Model do
     xorout: 0x0000000000000000..0xffffffffffffffff,
     check: 0x0000000000000000..0xffffffffffffffff,
     residue: 0x0000000000000000..0xffffffffffffffff,
-    name: binary(),
+    name: binary,
     key: atom(),
     aliases: %{
-      optional(atom()) => binary()
+      optional(atom()) => binary
     },
     slow: boolean(),
     value: non_neg_integer()
@@ -240,7 +240,7 @@ defmodule CRC.Model do
     acc = %{ acc | aliases: aliases }
     parse(rest, acc)
   end
-  defp parse(<< ?\n, rest :: binary() >>, acc) do
+  defp parse(<< ?\n, rest :: binary >>, acc) do
     acc =
       if is_nil(acc.sick) do
         %{ acc | sick: false }
@@ -263,7 +263,7 @@ defmodule CRC.Model do
       {:ok, acc, rest}
     end
   end
-  defp parse(<< _, rest :: binary() >>, acc) do
+  defp parse(<< _, rest :: binary >>, acc) do
     parse(rest, acc)
   end
   defp parse(<<>>, acc) do
@@ -284,39 +284,39 @@ defmodule CRC.Model do
   defp take_until_whitespace(<<>>, acc) do
     {<<>>, acc}
   end
-  defp take_until_whitespace(rest = << ?\n, _ :: binary() >>, acc) do
+  defp take_until_whitespace(rest = << ?\n, _ :: binary >>, acc) do
     {rest, acc}
   end
-  defp take_until_whitespace(<< ?\s, rest :: binary() >>, acc) do
+  defp take_until_whitespace(<< ?\s, rest :: binary >>, acc) do
     {rest, acc}
   end
-  defp take_until_whitespace(<< c, rest :: binary() >>, acc) do
-    take_until_whitespace(rest, << acc ::binary(), c >>)
+  defp take_until_whitespace(<< c, rest :: binary >>, acc) do
+    take_until_whitespace(rest, << acc ::binary, c >>)
   end
 
   @doc false
-  defp underscore(<< ?", rest :: binary() >>, acc) do
+  defp underscore(<< ?", rest :: binary >>, acc) do
     underscore(rest, acc)
   end
-  defp underscore(<< c, rest :: binary() >>, acc) when c in ?A..?Z do
-    underscore(rest, << acc :: binary(), (c + 32) >>)
+  defp underscore(<< c, rest :: binary >>, acc) when c in ?A..?Z do
+    underscore(rest, << acc :: binary, (c + 32) >>)
   end
-  defp underscore(<< c, rest :: binary() >>, acc) when c in ?a..?z or c in ?0..?9 do
-    underscore(rest, << acc :: binary(), c >>)
+  defp underscore(<< c, rest :: binary >>, acc) when c in ?a..?z or c in ?0..?9 do
+    underscore(rest, << acc :: binary, c >>)
   end
-  defp underscore(<< c, rest :: binary() >>, acc) when c in [?-, ?/] do
-    underscore(rest, << acc :: binary(), ?_ >>)
+  defp underscore(<< c, rest :: binary >>, acc) when c in [?-, ?/] do
+    underscore(rest, << acc :: binary, ?_ >>)
   end
   defp underscore(<<>>, acc) do
     acc
   end
 
   @doc false
-  defp strip_quotes(<< ?", rest :: binary() >>, acc) do
+  defp strip_quotes(<< ?", rest :: binary >>, acc) do
     strip_quotes(rest, acc)
   end
-  defp strip_quotes(<< c, rest :: binary() >>, acc) do
-    strip_quotes(rest, << acc :: binary(), c >>)
+  defp strip_quotes(<< c, rest :: binary >>, acc) do
+    strip_quotes(rest, << acc :: binary, c >>)
   end
   defp strip_quotes(<<>>, acc) do
     acc

--- a/test/crc_test.exs
+++ b/test/crc_test.exs
@@ -1,7 +1,7 @@
 defmodule CRCTest do
   use ExUnit.Case
   use PropCheck
-  use Bitwise
+  import Bitwise
   doctest CRC
 
   @test_data_01 "123456789"

--- a/test/crc_test.exs
+++ b/test/crc_test.exs
@@ -190,7 +190,7 @@ defmodule CRCTest do
           |> String.trim()
         results =
           case results do
-            << "0x", rest :: binary() >> -> rest
+            << "0x", rest :: binary >> -> rest
             _ -> results
           end
         crc_le = :erlang.binary_to_integer(results, 16)
@@ -249,7 +249,7 @@ defmodule CRCTest do
           |> String.trim()
         results =
           case results do
-            << "0x", rest :: binary() >> -> rest
+            << "0x", rest :: binary >> -> rest
             _ -> results
           end
         crc_le = :erlang.binary_to_integer(results, 16)

--- a/test/support/checksum_xor.ex
+++ b/test/support/checksum_xor.ex
@@ -1,5 +1,5 @@
 defmodule ChecksumXOR do
-  use Bitwise
+  import Bitwise
 
   def calc(input) do
     calc(input, 0)

--- a/test/support/checksum_xor.ex
+++ b/test/support/checksum_xor.ex
@@ -10,7 +10,7 @@ defmodule ChecksumXOR do
     sum
   end
   defp calc(<< c, rest :: binary() >>, sum) do
-    calc(rest, sum ^^^ c)
+    calc(rest, bxor(sum, c))
   end
 
 end

--- a/test/support/crc_16.ex
+++ b/test/support/crc_16.ex
@@ -1,5 +1,5 @@
 defmodule CRC16 do
-  use Bitwise
+  import Bitwise
 
   @crc16 0x8005
 

--- a/test/support/crc_16.ex
+++ b/test/support/crc_16.ex
@@ -35,7 +35,7 @@ defmodule CRC16 do
     if flag === 0 do
       do_final(crc, i + 1)
     else
-      do_final(crc ^^^ @crc16, i + 1)
+      do_final(bxor(crc, @crc16), i + 1)
     end
   end
 
@@ -62,7 +62,7 @@ defmodule CRC16 do
     if flag === 0 do
       do_update(crc, c, read + 1)
     else
-      do_update(crc ^^^ @crc16, c, read + 1)
+      do_update(bxor(crc, @crc16), c, read + 1)
     end
   end
 

--- a/test/support/crc_8_koop.ex
+++ b/test/support/crc_8_koop.ex
@@ -10,7 +10,7 @@ defmodule CRC8KOOP do
   end
 
   def init(seed \\ 0xff) do
-    seed ^^^ 0xff
+    bxor(seed, 0xff)
   end
 
   def update(crc, <<>>) do
@@ -29,7 +29,7 @@ defmodule CRC8KOOP do
   @doc false
   defp do_final(crc, 8) do
     crc = reflect(crc, 8)
-    (crc ^^^ 0xff) &&& 0xff
+    (bxor(crc, 0xff)) &&& 0xff
   end
   defp do_final(crc, i) do
     bit = crc &&& 0x80
@@ -37,7 +37,7 @@ defmodule CRC8KOOP do
     if bit === 0 do
       do_final(crc, i + 1)
     else
-      do_final(crc ^^^ 0x4d, i + 1)
+      do_final(bxor(crc, 0x4d), i + 1)
     end
   end
 
@@ -51,7 +51,7 @@ defmodule CRC8KOOP do
     if bit === 0 do
       do_update(crc, c, i + 1)
     else
-      do_update(crc ^^^ 0x4d, c, i + 1)
+      do_update(bxor(crc, 0x4d), c, i + 1)
     end
   end
 

--- a/test/support/crc_8_koop.ex
+++ b/test/support/crc_8_koop.ex
@@ -1,5 +1,5 @@
 defmodule CRC8KOOP do
-  use Bitwise
+  import Bitwise
 
   # Adapted from ./pycrc.py --generate=c --algorithm=bbb --model=crc-8-koop
 


### PR DESCRIPTION
This PR fixes Elixir compiler warnings:

```
warning: extra parentheses on a bitstring specifier "binary()" have been deprecated. Please remove the parentheses: "binary"
warning: use Mix.Config is deprecated. Use the Config module instead
warning: use Bitwise is deprecated. import Bitwise instead
warning: ^^^ is deprecated. It is typically used as xor but it has the wrong precedence, use Bitwise.bxor/2 instead
```
